### PR TITLE
Fix deprecation warning in picker.maxDate

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1682,7 +1682,7 @@
                 throw new TypeError('maxDate() date parameter is before options.minDate: ' + parsedDate.format(actualFormat));
             }
             options.maxDate = parsedDate;
-            if (options.useCurrent && !options.keepInvalid && date.isAfter(maxDate)) {
+            if (options.useCurrent && !options.keepInvalid && date.isAfter(parsedDate)) {
                 setValue(options.maxDate);
             }
             if (viewDate.isAfter(parsedDate)) {


### PR DESCRIPTION
maxDate has been parsed already in line 1685, use this parsedDate in call to isAfter to avoid deprecation warning:
Deprecation warning: moment construction falls back to js Date. This is discouraged and will be removed in upcoming major release. Please refer to https://github.com/moment/moment/issues/1407 for more info.